### PR TITLE
- added within overrides for the vertex class

### DIFF
--- a/dxflib++/include/entities/hatch.h
+++ b/dxflib++/include/entities/hatch.h
@@ -101,10 +101,11 @@ namespace dxflib::entities
 		const vertex& get_elevation_point() const { return elevation_; } // Returns the elevation of the hatch
 		const std::string& get_hatch_pattern() const { return hatch_pattern_; } // Returns the hatch pattern name
 		bool is_solid() const { return is_solid_; } // Returns true if the hatch pattern is solid
-		bool is_associated() const { return polyline_ptr_ == nullptr; } // Returns true if the hatch has an associated lwpolyline
+		bool is_associated() const { return polyline_ptr_ != nullptr; } // Returns true if the hatch has an associated lwpolyline
 		int path_count() const { return path_count_; } // Returns the number of paths that are associated with the hatch
 		double get_pattern_angle() const { return pattern_angle_; } // Returns the hatch pattern angle (Must be !solid)
 		double get_pattern_scale() const { return pattern_scale_; } // Returns the hatch patter scale (Must be !solid) 
+		const std::vector<geoline>& get_geolines() const { return geolines_; }
 		// Set
 		void set_lwpolyline(lwpolyline* in) { polyline_ptr_ = in; } // Sets the lwpolyline pointer of the hatch
 		// Other functions

--- a/dxflib++/include/entities/lwpolyline.h
+++ b/dxflib++/include/entities/lwpolyline.h
@@ -108,8 +108,7 @@ namespace dxflib::entities
 		double get_length() const { return length_; } // Returns the length of the lwpolyline
 		double get_area() const { return area_; } // Returns the area of the lwpolyline
 		double is_drawn_ccw() const { return drawn_counter_clockwise_; }
-		// Returns true if the polyline was drawn counterclock-wise
-
+		const lwpolyline* get_within_pointer() const { return within_pointer_; }
 		// Set
 		void set_elevation(const double new_elevation) // Sets the elevation of the lwpolyline
 		{
@@ -119,7 +118,7 @@ namespace dxflib::entities
 		void move_vertex(int id, const vertex& new_vertex); // Moves the vertex[id] to new location
 
 		// Other functions
-		bool within(const vertex& v) const;
+		bool within(const lwpolyline& pl);
 		friend std::ostream& operator<<(std::ostream& os, lwpolyline);
 
 	private:
@@ -134,6 +133,8 @@ namespace dxflib::entities
 		double length_{}; // total length of the polyline
 		double area_{}; // Total area of the polyline
 		bool drawn_counter_clockwise_{};
+
+		const lwpolyline* within_pointer_{ nullptr };
 
 		/**
 		 * \brief Function that calculates the total length & area of the polyline

--- a/dxflib++/include/entities/point.h
+++ b/dxflib++/include/entities/point.h
@@ -1,9 +1,10 @@
 #pragma once
 #include <ostream>
-
+#include <vector>
 namespace dxflib::entities
 {
 	class lwpolyline;
+	class geoline;
 	/**
 	* \brief point base class
 	*/
@@ -29,5 +30,6 @@ namespace dxflib::entities
 		*/
 		explicit vertex(double x = 0, double y = 0, double z = 0);
 		bool within(const lwpolyline& pl) const;
+		bool within(const std::vector<geoline>& gl_vector) const;
 	};
 }

--- a/dxflib++/src/cadfile.cpp
+++ b/dxflib++/src/cadfile.cpp
@@ -185,10 +185,6 @@ void dxflib::cadfile::linker()
 {
 	for (auto& hatch : hatches_)
 	{
-		// If the hatch is explicitly not associated with a polyline then
-		// dont bother searching
-		if (!hatch.is_associated())
-			continue;
 		for (auto& polyline : lwpolylines_)
 		{
 			if (hatch.get_soft_pointer() == polyline.get_handle())

--- a/dxflib++/src/entities/hatch.cpp
+++ b/dxflib++/src/entities/hatch.cpp
@@ -225,7 +225,8 @@ bool dxflib::entities::hatch::within(const vertex& v) const
 	{
 		if (!polyline_ptr_->is_closed())
 			return false;
-		return polyline_ptr_->within(v);
+		// TODO: Adam: rewrite the hatch within function
+		// return polyline_ptr_->within(v);
 	}
 	return mathlib::winding_num(geolines_, v);
 }

--- a/dxflib++/src/entities/point.cpp
+++ b/dxflib++/src/entities/point.cpp
@@ -17,7 +17,12 @@ bool dxflib::entities::vertex::within(const lwpolyline& pl) const
 {
 	if (!pl.is_closed())
 		return false;
-	return mathlib::winding_num(pl.get_lines(), *this);
+	return mathlib::winding_num(pl.get_lines(), *this) != 0;
+}
+
+bool dxflib::entities::vertex::within(const std::vector<geoline>& gl_vector) const
+{
+	return mathlib::winding_num(gl_vector, *this) != 0;
 }
 
 std::ostream& dxflib::entities::operator<<(std::ostream& os, const point_base pb)


### PR DESCRIPTION
- cadfille.cpp linker(): removed the test to see if a polyline is associative
- lwpolyline.cpp/.h: changed the within function for lwpolyline class
- added within "precedence"