### PR TITLE
Arc segment within

### DIFF
--- a/cadfile_test/Entities/lwpolyline_tests.cpp
+++ b/cadfile_test/Entities/lwpolyline_tests.cpp
@@ -5,13 +5,23 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 TEST_CLASS(lwpolyline)
 {
-	TEST_METHOD(within_test)
+	TEST_METHOD(within_test_non_arced)
 	{
-		dxflib::cadfile c_file{ R"(C:\Dev\Test_DXF_files\lwpolyline\within_test.dxf)" };
+		dxflib::cadfile c_file{ R"(C:\Dev\Test_DXF_files\lwpolyline\within_test_non_arced.dxf)" };
 
 		for (const auto& pl : c_file.get_lwpolylines())
 			for (const auto& t : c_file.get_text())
 				Assert::IsTrue(t.first_alignment().within(pl),
 					std::wstring{t.get_string().begin(), t.get_string().end()}.c_str());
+	}
+
+	TEST_METHOD(within_test_arced)
+	{
+		dxflib::cadfile c_file{ R"(C:\Dev\Test_DXF_files\lwpolyline\within_test_arced.dxf)" };
+
+		for (const auto& pl : c_file.get_lwpolylines())
+			for (const auto& t : c_file.get_text())
+				Assert::IsTrue(t.first_alignment().within(pl),
+					std::wstring{ t.get_string().begin(), t.get_string().end() }.c_str());
 	}
 };

--- a/cadfile_test/Entities/lwpolyline_tests.cpp
+++ b/cadfile_test/Entities/lwpolyline_tests.cpp
@@ -1,0 +1,17 @@
+#include "dxflib++/include/Cadfile.h"
+#include <CppUnitTest.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+TEST_CLASS(lwpolyline)
+{
+	TEST_METHOD(within_test)
+	{
+		dxflib::cadfile c_file{ R"(C:\Dev\Test_DXF_files\lwpolyline\within_test.dxf)" };
+
+		for (const auto& pl : c_file.get_lwpolylines())
+			for (const auto& t : c_file.get_text())
+				Assert::IsTrue(t.first_alignment().within(pl),
+					std::wstring{t.get_string().begin(), t.get_string().end()}.c_str());
+	}
+};

--- a/cadfile_test/cadfile_test.vcxproj
+++ b/cadfile_test/cadfile_test.vcxproj
@@ -163,6 +163,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Entities\line_test.cpp" />
+    <ClCompile Include="Entities\lwpolyline_tests.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/cadfile_test/cadfile_test.vcxproj.filters
+++ b/cadfile_test/cadfile_test.vcxproj.filters
@@ -32,5 +32,8 @@
     <ClCompile Include="Entities\line_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Entities\lwpolyline_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/dxflib++/include/entities/lwpolyline.h
+++ b/dxflib++/include/entities/lwpolyline.h
@@ -31,7 +31,7 @@ namespace dxflib::entities
 		double get_bulge() const { return bulge_; } // Returns the bulge of the geoline
 		double get_area() const { return area_; } // Returns the area between the geoline and the x-axis
 		inline double get_radius() const; // Returns the radius of the geoline: INF if bulge == bulge_null
-		inline double get_angle() const; // Returns the angle of the geoline: INF if bulge == bulge_null
+		double get_angle() const; // Returns the angle of the geoline: INF if bulge == bulge_null
 		friend std::ostream& operator<<(std::ostream& os, geoline& geoline);
 
 	protected:

--- a/dxflib++/include/mathlib.h
+++ b/dxflib++/include/mathlib.h
@@ -162,5 +162,14 @@ namespace dxflib::mathlib
 		bool has_verticies_;
 	};
 
+	/**
+	 * \brief Computes the winding number of a vertex and a closed set of geolines
+	 * \param geolines input a vector of geolines that surroud the point in question
+	 * \param v the vertex in question
+	 * \return the winding number. 
+	 */
 	int winding_num(const std::vector<entities::geoline>& geolines, const entities::vertex& v);
+
+	bool is_within_arc(const entities::vertex& p1, const entities::vertex& p,
+	                   const entities::vertex& p2, double total_angle);
 }

--- a/dxflib++/src/entities/lwpolyline.cpp
+++ b/dxflib++/src/entities/lwpolyline.cpp
@@ -86,7 +86,7 @@ inline double dxflib::entities::geoline::get_radius() const
 	return bulge_ == static_cast<double>(bulge_null) ? std::numeric_limits<double>::infinity() : radius_;
 }
 
-inline double dxflib::entities::geoline::get_angle() const
+double dxflib::entities::geoline::get_angle() const
 {
 	return bulge_ == static_cast<double>(bulge_null) ? std::numeric_limits<double>::infinity() : total_angle_;
 }

--- a/dxflib++/src/mathlib/vector.cpp
+++ b/dxflib++/src/mathlib/vector.cpp
@@ -105,14 +105,19 @@ int dxflib::mathlib::winding_num(const std::vector<entities::geoline>& geolines,
 	int sum{0};
 	for (const auto& line : geolines)
 	{
-		const basic_vector line_vector{line};
+		// Loop constants
+		const basic_vector line_vector{line}; // the line vector
 		bool in_arc{ false };
+
+		// if the line is an arc then test to see if it is within the arc.
 		if (line.get_bulge() != entities::geoline::bulge_null)
 			in_arc = is_within_arc(line[0], v, line[1], line.get_angle());
 		if (line[0].y > v.y && line[1].y > v.y && !in_arc) // Line is above
 			continue;
 		if (line[0].y < v.y && line[1].y < v.y && !in_arc) // Line is below
 			continue;
+
+		// Bug: Line could still be right of point and this will not flag it
 		if (line[0].x < v.x && line[1].x < v.x && !in_arc) // Line is to the right
 			continue;
 		if (in_arc && line.get_bulge() < 0)

--- a/dxflib++/src/mathlib/vector.cpp
+++ b/dxflib++/src/mathlib/vector.cpp
@@ -122,6 +122,21 @@ int dxflib::mathlib::winding_num(const std::vector<entities::geoline>& geolines,
 	return sum;
 }
 
+bool dxflib::mathlib::is_within_arc(const entities::vertex& p1, const entities::vertex& p, const entities::vertex& p2,
+                                    const double total_angle)
+{
+	const basic_vector p1_p{p1, p};
+	const basic_vector p1_p2{p1, p2};
+	const basic_vector p2_p{p2, p};
+	const basic_vector p2_p1{p2, p1};
+
+	const double phi_1{basic_vector::dot_product(p1_p, p1_p2) / (p1_p.magnitude() * p1_p2.magnitude())};
+	const double phi_2{basic_vector::dot_product(p2_p, p2_p1) / (p2_p.magnitude() * p2_p1.magnitude())};
+
+	const double sum{phi_1 + phi_2};
+	return sum > 0 && sum < total_angle / 2;
+}
+
 std::ostream& dxflib::mathlib::operator<<(std::ostream& os, const basic_vector& bv)
 {
 	os << "[" << bv.x() << "i, " << bv.y() << "j, " << bv.z() << "k]";

--- a/dxflib++/src/mathlib/vector.cpp
+++ b/dxflib++/src/mathlib/vector.cpp
@@ -129,7 +129,7 @@ int dxflib::mathlib::winding_num(const std::vector<entities::geoline>& geolines,
 		const double x_unit_vector_cross_l0_l1{basic_vector::cross_product(x_unit_vector, l0_l1).z()};
 
 		/*
-		 * There is a special case where the point is to the left of the line but is no left of both
+		 * There is a special case where the point is to the left of the line but is not left of both
 		 * points of the line. To determine if the point is in this condition we need to compare the two cross
 		 * products that we calculated above. The signs will differ if 
 		 */

--- a/dxflib++/src/mathlib/vector.cpp
+++ b/dxflib++/src/mathlib/vector.cpp
@@ -147,6 +147,12 @@ int dxflib::mathlib::winding_num(const std::vector<entities::geoline>& geolines,
 bool dxflib::mathlib::is_within_arc(const entities::vertex& p1, const entities::vertex& p, const entities::vertex& p2,
                                     const double total_angle)
 {
+	// TODO: add comment about how this works
+	/*
+	 * Is within arc function:
+	 *  
+	 */
+
 	const basic_vector p1_p{p1, p};
 	const basic_vector p1_p2{p1, p2};
 	const basic_vector p2_p{p2, p};


### PR DESCRIPTION
Implementing the winding number function to also take into account arcs in polylines. It is not quite ready yet. There are some bugs that I am working out.
Here is a link to the algorithm that I am using for the base polyline winding number.. for reference.
[Geomalgorithms](http://geomalgorithms.com/a03-_inclusion.html)

Also, here is a link that shows the functions that can be used to determine different properties of an arc:

[Arcs and Bulges](http://www.lee-mac.com/bulgeconversion.html)

For reference here is an image depicting some of the above article.

![](http://www.lee-mac.com/lisp/gifs/Bulge2Arc.png)
