### PR TITLE
Within bugs

### DIFF
--- a/dxflib++/include/entities/lwpolyline.h
+++ b/dxflib++/include/entities/lwpolyline.h
@@ -24,6 +24,9 @@ namespace dxflib::entities
 		                                           const std::vector<double>& y, const std::vector<double>& bulge,
 		                                           bool is_closed);
 
+		// Returns the draw direction of a set of geolines
+		static double draw_direction(const geoline&, const geoline&);
+
 		// Public Interface 
 		const vertex& operator[](int id) const; // Returns a vertex of the geoline 0 or 1
 		vertex& operator[](int id); // Returns a vertex of the geoline 0 or 1

--- a/dxflib++/src/entities/lwpolyline.cpp
+++ b/dxflib++/src/entities/lwpolyline.cpp
@@ -49,6 +49,17 @@ std::vector<dxflib::entities::geoline> dxflib::entities::geoline::geoline_binder
 	return geolines;
 }
 
+double dxflib::entities::geoline::draw_direction(const geoline& p0_p1, const geoline& p1_p2)
+{
+	/*
+	 * Function used to determine the draw direction of a set of geolines. This 
+	 * is useful for determining if a bulge is convex or concave
+	 */
+	const mathlib::basic_vector v0{ p0_p1 };
+	const mathlib::basic_vector v1{ p1_p2 };
+	return mathlib::basic_vector::cross_product(v0, v1).z();
+}
+
 const dxflib::entities::vertex& dxflib::entities::geoline::operator[](const int id) const
 {
 	switch (id)

--- a/dxflib++/src/entities/lwpolyline.cpp
+++ b/dxflib++/src/entities/lwpolyline.cpp
@@ -6,12 +6,12 @@ dxflib::entities::geoline::geoline(const vertex& v0, const vertex& v1, const dou
 	v0_(v0), v1_(v1),
 	bulge_(bulge)
 {
-	if (bulge_ == bulge_null)
+	if (bulge_ == bulge_null) // If segment is a straight line
 	{
 		length_ = mathlib::distance(v0_, v1_);
 		area_ = mathlib::trapz_area(v0_, v1_);
 	}
-	else
+	else // If segment is not a straight line
 	{
 		length_ = mathlib::distance(v0_, v1_, bulge_);
 		total_angle_ = 4 * std::atan(bulge_);


### PR DESCRIPTION
Fixed some more bugs that were present in the winding number function. There were a few special cases that were not giving the correct answer. For example, now the winding number function can determine if a bulge is convex or concave and tell if the point should be considered in or out based on that fact.